### PR TITLE
[fix] 로그인 DTO 필드명 및 LocalStrategy usernameField 정합성

### DIFF
--- a/src/common/guards/local.strategy.ts
+++ b/src/common/guards/local.strategy.ts
@@ -6,7 +6,7 @@ import { AuthService } from '../../auth/auth.service';
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
   constructor(private authService: AuthService) {
-    super();
+    super({ usernameField: 'email' });
   }
   private readonly logger = new Logger(LocalStrategy.name);
 

--- a/src/user/dto/signin-user.dto.ts
+++ b/src/user/dto/signin-user.dto.ts
@@ -11,7 +11,7 @@ export class SignInUserDto {
   @IsNotEmpty()
   @IsEmail()
   @Length(6, 60)
-  readonly username!: string;
+  readonly email!: string;
 
   @ApiProperty({
     description: 'User Password',


### PR DESCRIPTION
## 변경 내용

Closes #1 (부분)

### 수정
- `src/user/dto/signin-user.dto.ts`: `username` → `email`
- `src/common/guards/local.strategy.ts`: `super({ usernameField: 'email' })` 추가

### 검증
- `npm run build` ✅
- `npm test` ✅ (20 tests passed)